### PR TITLE
Shellwords 1.8.6 compat

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -338,7 +338,7 @@ module Net
       # (See Net::SCP::Upload and Net::SCP::Download).
       def start_command(mode, local, remote, options={}, &callback)
         session.open_channel do |channel|
-          command = "#{scp_command(mode, options)} #{remote.shellescape}"
+          command = "#{scp_command(mode, options)} #{shellescape remote}"
           channel.exec(command) do |ch, success|
             if success
               channel[:local   ] = local
@@ -398,6 +398,27 @@ module Net
       # set, this does nothing.
       def progress_callback(channel, name, sent, total)
         channel[:callback].call(channel, name, sent, total) if channel[:callback]
+      end
+
+      # Imported from ruby 1.9.2 shellwords.rb
+      def shellescape(str)
+        # ruby 1.8.7+ implements String#shellescape
+        return str.shellescape if str.respond_to? :shellescape
+
+        # An empty argument will be skipped, so return empty quotes.
+        return "''" if str.empty?
+
+        str = str.dup
+
+        # Process as a single byte sequence because not all shell
+        # implementations are multibyte aware.
+        str.gsub!(/([^A-Za-z0-9_\-.,:\/@\n])/n, "\\\\\\1")
+
+        # A LF cannot be escaped with a backslash because a backslash + LF
+        # combo is regarded as line continuation and simply ignored.
+        str.gsub!(/\n/, "'\n'")
+
+        return str
       end
   end
 end


### PR DESCRIPTION
So I looked into the pre-1.8.7 shellwords library, and it didn't provide the necessary escaping method. So instead of fretting about this, I thought it would be appropriate to just pull in the method from the 1.9.2 release since Shellwords#shellescape is really just a wrapper around a little regex.

I don't think this will require much maintenance into the future, and if you drop 1.8.6 compat someday, you can just revert this commit. All tests pass for ruby 1.8.6, 1.8.7, and 1.9.2.

Hope your computer holiday was nice. My buddy is in Montreal too, and I think he's trying to enjoy the last bits of the summer while it's around.

Cheers,
Sung
