### PR TITLE
Fix tests for Ruby 1.9.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,10 @@ version = @spec.version
 
 # TESTS/SPECS =========================================================
 
-
+require 'rake/testtask'
+Rake::TestTask.new do |t|
+  t.libs = ["lib", "test"]
+end
 
 # INSTALL =============================================================
 

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -1,3 +1,0 @@
-Dir.chdir(File.dirname(__FILE__)) do
-  Dir['**/test_*.rb'].each { |file| require(file) }
-end


### PR DESCRIPTION
Hi there!

We've hit issues in Gentoo with Ruby 1.9.2 because of "." not being in the default library path anymore. I've worked it around in our builds for now, but this change should make it more in-line with other Ruby packages and incidentally solves the issue as well.

HTH,
Diego
