### PR TITLE
Allow passing a shell to use when executing scp.

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -338,7 +338,14 @@ module Net
       # (See Net::SCP::Upload and Net::SCP::Download).
       def start_command(mode, local, remote, options={}, &callback)
         session.open_channel do |channel|
-          command = "#{scp_command(mode, options)} #{shellescape remote}"
+        
+          if options[:shell]
+            escaped_file = shellescape(remote).gsub(/'/) { |m| "'\\''" }
+            command = "#{options[:shell]} -c '#{scp_command(mode, options)} #{escaped_file}'"
+          else
+            command = "#{scp_command(mode, options)} #{shellescape remote}"
+          end
+
           channel.exec(command) do |ch, success|
             if success
               channel[:local   ] = local


### PR DESCRIPTION
This adds an option to Net::SCP calls to allow wrapping the call to `scp` itself in a different shell. This might not sound very useful at first, but allows to transfer files as different users.

E.g. in Capistrano

``` ruby
put "Some content", "/path/to/some/file", :shell => "sudo su - some-other-user", :via => :scp
```
