### PR TITLE
Convert to string in shellescape

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -401,7 +401,10 @@ module Net
       end
 
       # Imported from ruby 1.9.2 shellwords.rb
-      def shellescape(str)
+      def shellescape(path)
+        # Convert path to a string if it isn't already one.
+        str = path.to_s
+
         # ruby 1.8.7+ implements String#shellescape
         return str.shellescape if str.respond_to? :shellescape
 


### PR DESCRIPTION
I was using a custom object to represent a remote file and got an exception in `shellescape`  about my object not having an empty? method. While it's not to much of a problem to do `.to_s` for a remote file object in a call to `Net::SCP::download!`, it seems nice to include support for other path objects in scp.
