### PR TITLE
stop zlib warning if scp error occur

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -356,7 +356,10 @@ module Net
               channel[:state   ] = "#{mode}_start"
               channel[:stack   ] = []
 
-              channel.on_close                  { |ch| raise Net::SCP::Error, "SCP did not finish successfully (#{ch[:exit]})" if ch[:exit] != 0 }
+              channel.on_close{|ch|
+                channel.close
+                raise Net::SCP::Error, "SCP did not finish successfully (#{ch[:exit]})" if ch[:exit] != 0
+              }
               channel.on_data                   { |ch, data| channel[:buffer].append(data) }
               channel.on_extended_data          { |ch, type, data| debug { data.chomp } }
               channel.on_request("exit-status") { |ch, data| channel[:exit] = data.read_long }


### PR DESCRIPTION
If scp error occur, "zlib(finalizer): the stream was freed prematurely." message print to stderr.
I stop it.

Change point is as follows.
close ssh channel before raise
