### PR TITLE
add `:ssh` to `OpenURI::Options`

### DIFF
--- a/lib/uri/open-scp.rb
+++ b/lib/uri/open-scp.rb
@@ -10,7 +10,7 @@ module URI
     def buffer_open(buf, proxy, open_options)
       options = open_options.merge(:port => port, :password => password)
       progress = options.delete(:progress_proc)
-      buf << Net::SCP.download!(host, user, path, nil, open_options, &progress)
+      buf << Net::SCP.download!(host, user, path, nil, options, &progress)
       buf.io.rewind
     end
 


### PR DESCRIPTION
Without this OpenURI will raise an error saying "unrecognized option" when an `:ssh` key is on the options hash passed into open.

Also added a changeset to pass the correct options hash to `Net::SCP.download!`
