### PR TITLE
Set encoding to 'BINARY' when creating a StringIO - this will keep from ...

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -317,7 +317,7 @@ module Net
     #
     #   data = download!("/remote/path")
     def download!(remote, local=nil, options={}, &progress)
-      destination = local ? local : StringIO.new
+      destination = local ? local : StringIO.new.tap { |io| io.set_encoding('BINARY') }
       download(remote, destination, options, &progress).wait
       local ? true : destination.string
     end


### PR DESCRIPTION
This sets the encoding of the created StringIO (when doing download! to StringIO) to 'BINARY'.
Without this change, I was seeing weird errors downloading a zip file.   The file is 7402199 bytes, and doing a progress on the download showed it downloaded it all, but the returned StringIO's #length returned 7132662.
When I downloaded to a file instead, the file had the expected length of 7402199.   I did some searching and found http://blog.rayapps.com/2013/03/11/7-things-that-can-go-wrong-with-ruby-19-string-encodings/ (see #5 Sending binary data with default UTF-8 encoding).  Based on that, I modified net-scp like this and I was able to download my file properly.
