### PR TITLE
docs: Updating gem certificate location

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -78,7 +78,7 @@ However, in order to be sure the code you're installing hasn't been tampered wit
 
     # Add the public key as a trusted certificate
     # (You only need to do this once)
-    $ curl -O https://raw.github.com/net-ssh/net-ssh/master/gem-public_cert.pem
+    $ curl -O https://raw.githubusercontent.com/net-ssh/net-ssh/master/gem-public_cert.pem
     $ gem cert --add gem-public_cert.pem
 
 Then, when install the gem, do so with high security:


### PR DESCRIPTION
The curl command failed silently on my OSX system because it received a redirect 302 permanent and didn't follow it. This changes the URL to the current domain for raw Github file content.
