### PR TITLE
Test should not fail because of exception raised

### DIFF
--- a/test/test_download.rb
+++ b/test/test_download.rb
@@ -70,12 +70,10 @@ class TestDownload < Net::SCP::TestCase
     end
 
     error = nil
-    assert_scripted do
-      begin
-        scp.download!("/path/to/remote.txt")
-      rescue
-        error = $!
-      end
+    begin
+      scp.download!("/path/to/remote.txt")
+    rescue
+      error = $!
     end
     assert_equal Net::SCP::Error, error.class
     assert_equal "SCP did not finish successfully (1): File not found: /path/to/remote.txt\n", error.message


### PR DESCRIPTION
Since commit 4b36d0c08fc55d45ca4025daf4bad5c8349efcb4 in net-ssh, this
test fails. Since an exception is raised in the middle of the story, the
last steps are not processed, and assert_scripted fails.

Given an exception is raised in the middle of exception, it is expected
that the story cannot finish completely.
