### PR TITLE
Fix compatiblity with net-ssh 4.0+

### DIFF
--- a/test/test_download.rb
+++ b/test/test_download.rb
@@ -70,12 +70,12 @@ class TestDownload < Net::SCP::TestCase
     end
 
     error = nil
-    assert_scripted do
-      begin
-        scp.download!("/path/to/remote.txt")
-      rescue
-        error = $!
-      end
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+    begin
+      scp.download!("/path/to/remote.txt")
+    rescue
+      error = $!
+    end
     end
     assert_equal Net::SCP::Error, error.class
     assert_equal "SCP did not finish successfully (1): File not found: /path/to/remote.txt\n", error.message
@@ -116,7 +116,9 @@ class TestDownload < Net::SCP::TestCase
 
   def test_download_io_with_recursive_should_raise_error
     expect_scp_session "-f -r /path/to/remote.txt"
-    assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", StringIO.new, :recursive => true) }
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+      assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", StringIO.new, :recursive => true) }
+    end
   end
 
   def test_download_io_with_preserve_should_ignore_preserve
@@ -155,7 +157,9 @@ class TestDownload < Net::SCP::TestCase
       channel.gets_data "D0755 0 remote\n"
     end
 
-    assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote") }
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+      assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote") }
+    end
   end
 
   def test_download_should_raise_error_if_gets_not_ok
@@ -168,8 +172,10 @@ class TestDownload < Net::SCP::TestCase
       channel.gets_data "\1"
     end
 
-    e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", "/path/to/local.txt") }
-    assert_equal("\1", e.message)
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+      e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote.txt", "/path/to/local.txt") }
+      assert_equal("\1", e.message)
+    end
   end
 
   def test_download_directory_should_raise_error_if_local_exists_and_is_not_directory
@@ -185,8 +191,10 @@ class TestDownload < Net::SCP::TestCase
       channel.sends_ok
     end
 
-    e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote", "/path/to/local", :recursive => true) }
-    assert_match(/exists and is not a directory/, e.message)
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+      e = assert_raises(Net::SCP::Error) { scp.download!("/path/to/remote", "/path/to/local", :recursive => true) }
+      assert_match(/exists and is not a directory/, e.message)
+    end
   end
 
   def test_download_directory_should_create_directory_and_files_locally
@@ -211,7 +219,9 @@ class TestDownload < Net::SCP::TestCase
       channel.sends_ok
     end
 
-    scp.download!("/path/to/remote", "/path/to/local", :recursive => true, :ssh => { :verbose => :debug })
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+      scp.download!("/path/to/remote", "/path/to/local", :recursive => true, :ssh => { :verbose => :debug })
+    end
     assert_equal "a" * 1234, file.io.string
   end
 

--- a/test/test_upload.rb
+++ b/test/test_upload.rb
@@ -156,7 +156,9 @@ class TestUpload < Net::SCP::TestCase
       channel.gets_ok
     end
 
-    assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local", "/path/to/remote") }
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+      assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local", "/path/to/remote") }
+    end
   end
 
   def test_upload_empty_directory_should_create_directory_and_finish
@@ -274,7 +276,9 @@ class TestUpload < Net::SCP::TestCase
       channel.gets_data "\1"
     end
 
-    e = assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local.txt", "/path/to/remote.txt") }
-    assert_equal("\1", e.message)
+    Net::SSH::Test::Extensions::IO.with_test_extension do
+      e = assert_raises(Net::SCP::Error) { scp.upload!("/path/to/local.txt", "/path/to/remote.txt") }
+      assert_equal("\1", e.message)
+    end
   end
 end


### PR DESCRIPTION
This is my rather naive attempt to fix the test suite errors caused by [[1]]. It would be probably much better, if there was some method hiding this. @mfazekas what would you think about something like "assert_ssh_raises" (although this would not help to fix the "test_download_directory_should_create_directory_and_files_locally" test case).



[1]: https://github.com/net-ssh/net-ssh/commit/419048c3faa2709cae1242e85db60778a72687d8