### PR TITLE
Bump Ruby versions for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - "1.9.3"
-  - "2.0.0"
+  - "2.2.6"
+  - "2.3.3"
+  - "2.4.0"
+  - "ruby-head"
 
 
 install: gem install jeweler test-unit mocha net-ssh


### PR DESCRIPTION
Jeweler requires more recent Ruby ... and the Ruby specified in .travis.yml are obsolete anyway.