### PR TITLE
Support copying windows files with spaces

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -345,7 +345,7 @@ module Net
         session.open_channel do |channel|
 
           if options[:windows_path]
-            command = "#{scp_command(mode, options)} \"#{remote}\""
+            command = "#{scp_command(mode, options)} \"#{remote.gsub('\\', '/')}\""
           else
             if options[:shell]
               escaped_file = shellescape(remote).gsub(/'/) { |m| "'\\''" }

--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -194,7 +194,7 @@ module Net
     include Net::SSH::Loggable
     include Upload, Download
 
-    # Starts up a new SSH connection and instantiates a new SCP session on 
+    # Starts up a new SSH connection and instantiates a new SCP session on
     # top of it. If a block is given, the SCP session is yielded, and the
     # SSH session is closed automatically when the block terminates. If no
     # block is given, the SCP session is returned.
@@ -293,7 +293,7 @@ module Net
     # * :preserve - the atime and mtime of the file should be preserved.
     # * :verbose - the process should result in verbose output on the server
     #   end (useful for debugging).
-    # 
+    #
     # This method will return immediately, returning the Net::SSH::Connection::Channel
     # object that will support the download. To wait for the download to finish,
     # you can either call the #wait method on the channel, or otherwise run
@@ -343,12 +343,16 @@ module Net
       # (See Net::SCP::Upload and Net::SCP::Download).
       def start_command(mode, local, remote, options={}, &callback)
         session.open_channel do |channel|
-        
-          if options[:shell]
-            escaped_file = shellescape(remote).gsub(/'/) { |m| "'\\''" }
-            command = "#{options[:shell]} -c '#{scp_command(mode, options)} #{escaped_file}'"
+
+          if options[:windows_path]
+            command = "#{scp_command(mode, options)} \"#{remote}\""
           else
-            command = "#{scp_command(mode, options)} #{shellescape remote}"
+            if options[:shell]
+              escaped_file = shellescape(remote).gsub(/'/) { |m| "'\\''" }
+              command = "#{options[:shell]} -c '#{scp_command(mode, options)} #{escaped_file}'"
+            else
+              command = "#{scp_command(mode, options)} #{shellescape remote}"
+            end
           end
 
           channel.exec(command) do |ch, success|


### PR DESCRIPTION
Some people like me use net-scp with [Win32-OpenSSH](https://github.com/PowerShell/Win32-OpenSSH)... but scp doesn't work as a windows path could like this "C:\Program Files\Some folder".

The current code uses shellescape which is not friendly with windows paths. That is, every space(and maybe other chars) will be replaced with '\ ' which breaks the windows path. Moreover, net-scp doesn't expect a trailing \ in the path. So all windows \ should be replaced with /. 

We've been using this change for a while and haven't seen any issues so far. Hopefully, this change will be useful for other windows folks. 