### PR TITLE
Allow net-ssh 5.0 and test on modern ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: ruby
+cache: bundler
 rvm:
-  - "2.2.6"
-  - "2.3.3"
-  - "2.4.0"
-  - "ruby-head"
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
+  - ruby-head
 
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 
 install: gem install jeweler test-unit mocha net-ssh
 
 script: rake test
-

--- a/net-scp.gemspec
+++ b/net-scp.gemspec
@@ -30,16 +30,16 @@ Gem::Specification.new do |spec|
     spec.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      spec.add_runtime_dependency(%q<net-ssh>, [">= 2.6.5", "< 5.0.0"])
+      spec.add_runtime_dependency(%q<net-ssh>, [">= 2.6.5", "< 6.0.0"])
       spec.add_development_dependency(%q<test-unit>, [">= 0"])
       spec.add_development_dependency(%q<mocha>, [">= 0"])
     else
-      spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 5.0.0"])
+      spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 6.0.0"])
       spec.add_dependency(%q<test-unit>, [">= 0"])
       spec.add_dependency(%q<mocha>, [">= 0"])
     end
   else
-    spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 5.0.0"])
+    spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 6.0.0"])
     spec.add_dependency(%q<test-unit>, [">= 0"])
     spec.add_dependency(%q<mocha>, [">= 0"])
   end

--- a/net-scp.gemspec
+++ b/net-scp.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |spec|
   ]
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   if spec.respond_to? :specification_version then


### PR DESCRIPTION
There's a lot of great functionality in net-ssh 5, but you can't use it with this gem. This bumps the dep to allow that version and also tests on all the currently supported ruby releases in Travis.