### PR TITLE
Add changelog_uri to metadata to easily link from rubygems.org

### DIFF
--- a/net-scp.gemspec
+++ b/net-scp.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/net-ssh/net-scp"
   spec.license       = "MIT"
   spec.required_rubygems_version = Gem::Requirement.new(">= 0") if spec.respond_to? :required_rubygems_version=
+  spec.metadata      = {
+    "changelog_uri" => "https://github.com/net-ssh/net-scp/blob/master/CHANGES.txt"
+  }
 
   spec.extra_rdoc_files = [
     "LICENSE.txt",


### PR DESCRIPTION
Reference: https://guides.rubygems.org/specification-reference/#metadata