### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,6 @@ if false
     Jeweler::Tasks.new do |s|
       s.version = version
       s.name = name
-      s.rubyforge_project = s.name
       s.summary = "A pure Ruby implementation of the SCP client protocol"
       s.description = s.summary
       s.email = "net-ssh@solutious.com"


### PR DESCRIPTION
This is deprecated by rubygems:

NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.