### PR TITLE
Fix test failure under ruby2.7

### DIFF
--- a/test/common.rb
+++ b/test/common.rb
@@ -62,11 +62,11 @@ class Net::SCP::TestCase < Test::Unit::TestCase
     # handles newlines just fine, so we can be reasonably confident that they
     # will work in practice
     def awful_file_name
-      (((0x00..0x7f).to_a - [0x00, 0x0a, 0x2f]).map { |n| n.chr }).join + '.txt'
+      (((0x00..0x7f).to_a - [0x00, 0x0a, 0x2b, 0x2f]).map { |n| n.chr }).join + '.txt'
     end
 
     def escaped_file_name
-      "\\\001\\\002\\\003\\\004\\\005\\\006\\\a\\\b\\\t\\\v\\\f\\\r\\\016\\\017\\\020\\\021\\\022\\\023\\\024\\\025\\\026\\\027\\\030\\\031\\\032\\\e\\\034\\\035\\\036\\\037\\ \\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+,-.0123456789:\\;\\<\\=\\>\\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[\\\\\\]\\^_\\`abcdefghijklmnopqrstuvwxyz\\{\\|\\}\\~\\\177.txt"
+      "\\\001\\\002\\\003\\\004\\\005\\\006\\\a\\\b\\\t\\\v\\\f\\\r\\\016\\\017\\\020\\\021\\\022\\\023\\\024\\\025\\\026\\\027\\\030\\\031\\\032\\\e\\\034\\\035\\\036\\\037\\ \\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*,-.0123456789:\\;\\<\\=\\>\\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[\\\\\\]\\^_\\`abcdefghijklmnopqrstuvwxyz\\{\\|\\}\\~\\\177.txt"
     end
 
     class FileEntry


### PR DESCRIPTION
In ruby2.7 `+` is no longer escaped ShellWords.shellescape. In order to
make this test pass on ruby2.7 but also on older versions, drop the +
the string that is expected to be escaped.

Fixes #50