### PR TITLE
net-ssh 7.* support (for OpenSSL 3 compatibility)

### DIFF
--- a/net-scp.gemspec
+++ b/net-scp.gemspec
@@ -33,16 +33,16 @@ Gem::Specification.new do |spec|
     spec.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      spec.add_runtime_dependency(%q<net-ssh>, [">= 2.6.5", "< 7.0.0"])
+      spec.add_runtime_dependency(%q<net-ssh>, [">= 2.6.5", "< 8.0.0"])
       spec.add_development_dependency(%q<test-unit>, [">= 0"])
       spec.add_development_dependency(%q<mocha>, [">= 0"])
     else
-      spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 7.0.0"])
+      spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 8.0.0"])
       spec.add_dependency(%q<test-unit>, [">= 0"])
       spec.add_dependency(%q<mocha>, [">= 0"])
     end
   else
-    spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 7.0.0"])
+    spec.add_dependency(%q<net-ssh>, [">= 2.6.5", "< 8.0.0"])
     spec.add_dependency(%q<test-unit>, [">= 0"])
     spec.add_dependency(%q<mocha>, [">= 0"])
   end


### PR DESCRIPTION
This gem depends on `net-ssh < 7.0.0`, so we cannot use **net-ssh 7.0.1** which supports OpenSSL 3.
https://github.com/net-ssh/net-ssh/pull/864

Since Ruby 3.1 uses OpenSSL 3, using this gem with Ruby 3.1 may cause problems.

I want to set the dependency on `net-ssh < 8.0.0` so that I can use **net-ssh 7.0.1**.

Thanks!

