### PR TITLE
Use ruby 3.1's uri's register_scheme if available

### DIFF
--- a/lib/uri/scp.rb
+++ b/lib/uri/scp.rb
@@ -8,7 +8,7 @@ module URI
       :scheme,
       :userinfo,
       :host, :port, :path,
-      :query  
+      :query
     ].freeze
 
     attr_reader :options
@@ -31,5 +31,9 @@ module URI
     end
   end
 
-  @@schemes['SCP'] = SCP
+  if respond_to? :register_scheme
+    register_scheme "SCP", SCP
+  else
+    @@schemes["SCP"] = SCP
+  end
 end


### PR DESCRIPTION
Ruby 3.1 adopted uri 0.11.0. That version changes how schemes can be registered. There is now a register_scheme method.

https://github.com/ruby/uri/pull/26 as part of https://github.com/ruby/uri/releases/tag/v0.11.0

This commit supports both ways and works with the new method if available. The old way errors out when run  on uri>=0.11.0/ruby>=3.1.
