### PR TITLE
Fix issue #72: rake test fails with mocha > 2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ doc
 *.swp
 
 .DS_Store
+
+# Bundle local files
+/vendor/
+.bundle/config
+Gemfile.lock

--- a/test/common.rb
+++ b/test/common.rb
@@ -87,7 +87,8 @@ class Net::SCP::TestCase < Test::Unit::TestCase
     end
 
     def stub!
-      stat = Mocha::Mock.new('file::stat')
+      # Stub for File::Stat
+      stat = Object.new
       stat.stubs(size: contents.length, mode: mode, mtime: mtime, atime: atime, directory?: false)
 
       File.stubs(:stat).with(path).returns(stat)
@@ -128,7 +129,8 @@ class Net::SCP::TestCase < Test::Unit::TestCase
     def stub!
       Dir.stubs(:mkdir).with { |*a| a.first == path }
 
-      stat = Mocha::Mock.new('file::stat')
+      # Stub for File::Stat
+      stat = Object.new
       stat.stubs(size: 1024, mode: mode, mtime: mtime, atime: atime, directory?: true)
 
       File.stubs(:stat).with(path).returns(stat)

--- a/test/common.rb
+++ b/test/common.rb
@@ -2,7 +2,7 @@ require 'test/unit'
 require 'mocha/test_unit'
 
 begin
-  gem 'net-ssh', ">= 2.0.0"
+  gem 'net-ssh', '>= 2.0.0'
   require 'net/ssh'
 rescue LoadError
   $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../../net-ssh/lib"
@@ -10,7 +10,7 @@ rescue LoadError
   begin
     require 'net/ssh'
     require 'net/ssh/version'
-    raise LoadError, "wrong version" unless Net::SSH::Version::STRING >= '1.99.0'
+    raise LoadError, 'wrong version' unless Net::SSH::Version::STRING >= '1.99.0'
   rescue LoadError => e
     abort "could not load net/ssh v2 (#{e.inspect})"
   end
@@ -42,112 +42,118 @@ class Net::SCP::TestCase < Test::Unit::TestCase
 
   protected
 
-    def prepare_file(path, contents="", mode=0666, mtime=Time.now, atime=Time.now)
-      entry = FileEntry.new(path, contents, mode, mtime, atime)
-      entry.stub!
-      entry
+  def prepare_file(path, contents = '', mode = 0o0666, mtime = Time.now, atime = Time.now)
+    entry = FileEntry.new(path, contents, mode, mtime, atime)
+    entry.stub!
+    entry
+  end
+
+  def prepare_directory(path, mode = 0o0777, mtime = Time.now, atime = Time.now)
+    directory = DirectoryEntry.new(path, mode, mtime, atime)
+    yield directory if block_given?
+    directory.stub!
+  end
+
+  # The POSIX spec unfortunately allows all characters in file names except
+  # ASCII 0x00(NUL) and 0x2F(/)
+  #
+  # Ideally, we should be testing filenames with newlines, but Mocha doesn't
+  # like this at all, so we leave them out. However, the Shellwords module
+  # handles newlines just fine, so we can be reasonably confident that they
+  # will work in practice
+  def awful_file_name
+    (((0x00..0x7f).to_a - [0x00, 0x0a, 0x2b, 0x2f]).map { |n| n.chr }).join + '.txt'
+  end
+
+  def escaped_file_name
+    "\\\001\\\002\\\003\\\004\\\005\\\006\\\a\\\b\\\t\\\v\\\f\\\r\\\016\\\017\\\020\\\021\\\022\\\023\\\024\\\025" \
+      "\\\026\\\027\\\030\\\031\\\032\\\e\\\034\\\035\\\036\\\037\\ \\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*,-.0123456789:" \
+      "\\;\\<\\=\\>\\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[\\\\\\]\\^_\\`abcdefghijklmnopqrstuvwxyz\\{\\|\\}\\~\\\177.txt"
+  end
+
+  class FileEntry
+    attr_reader :path, :contents, :mode, :mtime, :atime, :io
+
+    def initialize(path, contents, mode = 0o0666, mtime = Time.now, atime = Time.now)
+      @path = path
+      @contents = contents
+      @mode = mode
+      @mtime = mtime
+      @atime = atime
     end
 
-    def prepare_directory(path, mode=0777, mtime=Time.now, atime=Time.now)
-      directory = DirectoryEntry.new(path, mode, mtime, atime)
-      yield directory if block_given?
-      directory.stub!
+    def name
+      @name ||= File.basename(path)
     end
 
-    # The POSIX spec unfortunately allows all characters in file names except
-    # ASCII 0x00(NUL) and 0x2F(/)
-    #
-    # Ideally, we should be testing filenames with newlines, but Mocha doesn't
-    # like this at all, so we leave them out. However, the Shellwords module
-    # handles newlines just fine, so we can be reasonably confident that they
-    # will work in practice
-    def awful_file_name
-      (((0x00..0x7f).to_a - [0x00, 0x0a, 0x2b, 0x2f]).map { |n| n.chr }).join + '.txt'
+    def stub!
+      stat = Mocha::Mock.new('file::stat')
+      stat.stubs(size: contents.length, mode: mode, mtime: mtime, atime: atime, directory?: false)
+
+      File.stubs(:stat).with(path).returns(stat)
+      File.stubs(:directory?).with(path).returns(false)
+      File.stubs(:file?).with(path).returns(true)
+      File.stubs(:open).with(path, 'rb').returns(StringIO.new(contents))
+
+      @io = StringIO.new
+      File.stubs(:new).with(path, 'wb', mode).returns(io)
+    end
+  end
+
+  class DirectoryEntry
+    attr_reader :path, :mode, :mtime, :atime, :entries
+
+    def initialize(path, mode = 0o0777, mtime = Time.now, atime = Time.now)
+      @path = path
+      @mode = mode
+      @mtime = mtime
+      @atime = atime
+      @entries = []
     end
 
-    def escaped_file_name
-      "\\\001\\\002\\\003\\\004\\\005\\\006\\\a\\\b\\\t\\\v\\\f\\\r\\\016\\\017\\\020\\\021\\\022\\\023\\\024\\\025\\\026\\\027\\\030\\\031\\\032\\\e\\\034\\\035\\\036\\\037\\ \\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*,-.0123456789:\\;\\<\\=\\>\\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[\\\\\\]\\^_\\`abcdefghijklmnopqrstuvwxyz\\{\\|\\}\\~\\\177.txt"
+    def name
+      @name ||= File.basename(path)
     end
 
-    class FileEntry
-      attr_reader :path, :contents, :mode, :mtime, :atime, :io
-
-      def initialize(path, contents, mode=0666, mtime=Time.now, atime=Time.now)
-        @path, @contents, @mode = path, contents, mode
-        @mtime, @atime = mtime, atime
-      end
-
-      def name
-        @name ||= File.basename(path)
-      end
-
-      def stub!
-        stat = Mocha::Mock.new("file::stat")
-        stat.stubs(:size => contents.length, :mode => mode, :mtime => mtime, :atime => atime, :directory? => false)
-
-        File.stubs(:stat).with(path).returns(stat)
-        File.stubs(:directory?).with(path).returns(false)
-        File.stubs(:file?).with(path).returns(true)
-        File.stubs(:open).with(path, "rb").returns(StringIO.new(contents))
-
-        @io = StringIO.new
-        File.stubs(:new).with(path, "wb", mode).returns(io)
-      end
+    def file(name, *args)
+      (entries << FileEntry.new(File.join(path, name), *args)).last
     end
 
-    class DirectoryEntry
-      attr_reader :path, :mode, :mtime, :atime
-      attr_reader :entries
-
-      def initialize(path, mode=0777, mtime=Time.now, atime=Time.now)
-        @path, @mode = path, mode
-        @mtime, @atime = mtime, atime
-        @entries = []
-      end
-
-      def name
-        @name ||= File.basename(path)
-      end
-
-      def file(name, *args)
-        (entries << FileEntry.new(File.join(path, name), *args)).last
-      end
-
-      def directory(name, *args)
-        entry = DirectoryEntry.new(File.join(path, name), *args)
-        yield entry if block_given?
-        (entries << entry).last
-      end
-
-      def stub!
-        Dir.stubs(:mkdir).with { |*a| a.first == path }
-
-        stat = Mocha::Mock.new("file::stat")
-        stat.stubs(:size => 1024, :mode => mode, :mtime => mtime, :atime => atime, :directory? => true)
-
-        File.stubs(:stat).with(path).returns(stat)
-        File.stubs(:directory?).with(path).returns(true)
-        File.stubs(:file?).with(path).returns(false)
-        Dir.stubs(:entries).with(path).returns(%w(. ..) + entries.map { |e| e.name }.sort)
-
-        entries.each { |e| e.stub! }
-      end
+    def directory(name, *args)
+      entry = DirectoryEntry.new(File.join(path, name), *args)
+      yield entry if block_given?
+      (entries << entry).last
     end
 
-    def expect_scp_session(arguments)
-      story do |session|
-        channel = session.opens_channel
-        channel.sends_exec "scp #{arguments}"
-        yield channel if block_given?
-        channel.sends_eof
-        channel.gets_exit_status
-        channel.gets_eof
-        channel.gets_close
-        channel.sends_close
-      end
-    end
+    def stub!
+      Dir.stubs(:mkdir).with { |*a| a.first == path }
 
-    def scp(options={})
-      @scp ||= Net::SCP.new(connection(options))
+      stat = Mocha::Mock.new('file::stat')
+      stat.stubs(size: 1024, mode: mode, mtime: mtime, atime: atime, directory?: true)
+
+      File.stubs(:stat).with(path).returns(stat)
+      File.stubs(:directory?).with(path).returns(true)
+      File.stubs(:file?).with(path).returns(false)
+      Dir.stubs(:entries).with(path).returns(%w[. ..] + entries.map { |e| e.name }.sort)
+
+      entries.each { |e| e.stub! }
     end
+  end
+
+  def expect_scp_session(arguments)
+    story do |session|
+      channel = session.opens_channel
+      channel.sends_exec "scp #{arguments}"
+      yield channel if block_given?
+      channel.sends_eof
+      channel.gets_exit_status
+      channel.gets_eof
+      channel.gets_close
+      channel.sends_close
+    end
+  end
+
+  def scp(options = {})
+    @scp ||= Net::SCP.new(connection(options))
+  end
 end


### PR DESCRIPTION
Using Mocha::Mock.new is not supported in mocha, and mock() does not work in a subclass of Test::Unit::TestCase
As we just need a stub for File:Statt an no mock, we just create an Object (instead of a mock) and stub it.

I've separated the pull request in two commits:
- first, fix rubocop warnings of test/common.rb
- second, fix the issue

Fixing the rubocop warnings of test/common.rb makes the PR somehow difficult to read. The fix itself is pretty small:
```diff
- stat = Mocha::Mock.new('file::stat')
+ # Stub for File::Stat
+ stat = Object.new
```

I've proposed this fix as I think you need the unit tests to work in order to make a new release. Would it be possible to release a new version of Net::SCP in the near future? I'd love see issue https://github.com/ytti/oxidized/issues/1802 being closed ;-) Is there something I can do to help producing a new release?

This PR fixes #72
