### PR TITLE
Allow for spaces in Windows file paths

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -345,7 +345,11 @@ module Net
         session.open_channel do |channel|
 
           if options[:windows_path]
-            command = "#{scp_command(mode, options)} #{remote.gsub('\\', '/')}"
+            escaped_file = remote.gsub(/'/) { |m| '/' }
+            unless escaped_file.index(' ').nil? || escaped_file.match?(/^'.+'$/)
+              escaped_file = "'#{escaped_file}'"
+            end
+            command = "#{scp_command(mode, options)} #{escaped_file}"
           elsif options[:shell]
             escaped_file = shellescape(remote).gsub(/'/) { |m| "'\\''" }
             command = "#{options[:shell]} -c '#{scp_command(mode, options)} #{escaped_file}'"


### PR DESCRIPTION
This fulfills the same purpose as #34, and adds a check to wrap the path in single quotes if it has a space. This also fixes #57. 