### PR TITLE
Fix Ruby 3.4 warning about frozen string literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'ruby-head']
     continue-on-error: ${{ matrix.ruby-version == 'ruby-head' }}
     steps:
       - uses: actions/checkout@v3

--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -329,7 +329,7 @@ module Net
       # (:verbose, :recursive, :preserve). Returns the command-line as a
       # string, ready to execute.
       def scp_command(mode, options)
-        command = "scp "
+        command = String.new("scp ")
         command << (mode == :upload ? "-t" : "-f")
         command << " -v" if options[:verbose]
         command << " -r" if options[:recursive]


### PR DESCRIPTION
This change fixes a warning in Ruby 3.4:
`warning: literal string will be frozen in the future`