### PR TITLE
Fix frozen string literal support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'ruby-head']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'ruby-head']
     continue-on-error: ${{ matrix.ruby-version == 'ruby-head' }}
     steps:
       - uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,12 @@ source 'https://rubygems.org'
 gemspec
 
 gem "net-ssh", ">= 7.3.1"
+gem "logger" # no longer a default gem in Ruby 4.0+
 
 # TODO: add to gemspec
 gem "bundler", ">= 1.11"
 gem "rake", ">= 12.0"
+gem "rdoc"
 
 gem 'byebug', group: %i[development test] if !Gem.win_platform? && RUBY_ENGINE == "ruby"
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in mygem.gemspec
 gemspec
 
+gem "net-ssh", ">= 7.3.1.rc1"
+
 # TODO: add to gemspec
 gem "bundler", ">= 1.11"
 gem "rake", ">= 12.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in mygem.gemspec
 gemspec
 
-gem "net-ssh", ">= 7.3.1.rc1"
+gem "net-ssh", ">= 7.3.1"
 
 # TODO: add to gemspec
 gem "bundler", ">= 1.11"

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require "rubygems"
 require "rake"
 require "rake/clean"
-require "rdoc/task"
+begin
+  require "rdoc/task"
+rescue LoadError
+end
 require "bundler/gem_tasks"
 
 desc "When releasing make sure NET_SSH_BUILDGEM_SIGNED is set"
@@ -67,17 +70,19 @@ Rake::TestTask.new do |t|
 end
 
 extra_files = %w[LICENSE.txt THANKS.txt CHANGES.txt ]
-RDoc::Task.new do |rdoc|
-  rdoc.rdoc_dir = "rdoc"
-  rdoc.title = "#{name} #{version}"
-  rdoc.generator = 'hanna' # gem install hanna-nouveau
-  rdoc.main = 'README.md'
-  rdoc.rdoc_files.include("README*")
-  rdoc.rdoc_files.include("bin/*.rb")
-  rdoc.rdoc_files.include("lib/**/*.rb")
-  extra_files.each { |file|
-    rdoc.rdoc_files.include(file) if File.exist?(file)
-  }
+if defined?(RDoc::Task)
+  RDoc::Task.new do |rdoc|
+    rdoc.rdoc_dir = "rdoc"
+    rdoc.title = "#{name} #{version}"
+    rdoc.generator = 'hanna' # gem install hanna-nouveau
+    rdoc.main = 'README.md'
+    rdoc.rdoc_files.include("README*")
+    rdoc.rdoc_files.include("bin/*.rb")
+    rdoc.rdoc_files.include("lib/**/*.rb")
+    extra_files.each { |file|
+      rdoc.rdoc_files.include(file) if File.exist?(file)
+    }
+  end
 end
 
 def change_version(&block)

--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -360,7 +360,7 @@ module Net
               channel[:buffer  ] = Net::SSH::Buffer.new
               channel[:state   ] = "#{mode}_start"
               channel[:stack   ] = []
-              channel[:error_string] = ''
+              channel[:error_string] = +''
 
               channel.on_close do
                 # If we got an exit-status and it is not 0, something went wrong


### PR DESCRIPTION
Fix frozen string literal compatibility and CI.

- Use mutable string (`+''`) for `channel[:error_string]` — was raising `FrozenError` instead of `Net::SCP::Error` when appending error messages
- Pin `net-ssh >= 7.3.1` in Gemfile for CI (frozen string fixes in net-ssh)
- Drop EOL Ruby 2.3–2.5 from CI matrix (net-ssh 7.x requires >= 2.6)
- Make rdoc/task optional for Ruby 4.0+ compatibility