### PR TITLE
Fix `FrozenError` still occurring on CI

### DIFF
--- a/lib/net/scp.rb
+++ b/lib/net/scp.rb
@@ -360,7 +360,7 @@ module Net
               channel[:buffer  ] = Net::SSH::Buffer.new
               channel[:state   ] = "#{mode}_start"
               channel[:stack   ] = []
-              channel[:error_string] = ''
+              channel[:error_string] = +''
 
               channel.on_close do
                 # If we got an exit-status and it is not 0, something went wrong


### PR DESCRIPTION
Support for frozen string literals was merged in https://github.com/net-ssh/net-scp/pull/75, but it seems some places still need fixes.

`FrozenError` still occurs on CI:
https://github.com/willnet/net-scp/actions/runs/23931026231/job/69797935847#step:4:36

There are destructive string operations in places such as https://github.com/net-ssh/net-scp/blob/f9cc5acef1af70061508a54b004ce17ef19028e8/lib/net/scp/download.rb#L43 , so make it explicit that the affected strings are not frozen.